### PR TITLE
ci: fix incorrect event type for commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,12 +1,14 @@
 ---
 name: Lint commit messages
-on: [pull-request]
+on: [pull_request]
 jobs:
   lint-commit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install modules
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "simple-test-runner",
-  "version": "1.0.0",
+  "name": "@dylan.pinn/simple-test-runner",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Incorrect event type added and now the commitlint GitHub Action is not
runnning.
